### PR TITLE
fix: handle cache miss in service worker

### DIFF
--- a/sw.js
+++ b/sw.js
@@ -57,7 +57,8 @@ self.addEventListener('fetch', (e) => {
       const fetchPromise = fetch(request).then(res => {
         cache.put(request, res.clone());
         return res;
-      }).catch(() => cached);
+      }).catch(() => cached || new Response(null, { status: 504 }));
+      e.waitUntil(fetchPromise); // keep SW alive for cache update
       return cached || fetchPromise;
     })());
     return;


### PR DESCRIPTION
## Summary
- avoid undefined responses for runtime assets when offline by returning fallback response
- keep service worker alive during cache updates

## Testing
- `npm test` (fails: Missing script: "test")
- `node --check sw.js`


------
https://chatgpt.com/codex/tasks/task_e_689c4a6881f88321bc264a7dd88d031f