### PR TITLE
feat: refresh catch copy and SEO text

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,8 +4,8 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
 
-  <title>ChuCkle Park Bar（チャックル パーク バー）| 本郷の路地で、ひそやかな社交と深いくつろぎを</title>
-  <meta name="description" content="名古屋・本郷の路地にあるバー『ChuCkle Park Bar』。社交も隠れ家も楽しめる空間で、豊富なドリンクと本格フード。カウンター8席・テーブル2〜8名、深夜2時まで温かいお料理をご提供。">
+   <title>ChuCkle Park Bar（チャックル パーク バー）| 夜を、もう一口たのしく。</title>
+   <meta name="description" content="名古屋・本郷の路地にあるバー『ChuCkle Park Bar』。夜を、もう一口たのしく。本格の一皿と幅広いドリンク、にぎやかで人当たりのいい接客。カウンター8席・テーブル2〜8名、深夜2時まで温かいお料理をご提供。">
 
   <meta name="keywords" content="本郷,バー,社交,隠れ家,路地,くつろぎ,ドリンク,アルコール,お酒,酒,フード,一人飲み,団体,テーブル席,名古屋,深夜営業,本郷駅,ChuCkle Park Bar,チャックル パーク バー,名東区,社が丘,地下鉄東山線" />
   <meta name="author" content="ChuCkle Park Bar" />
@@ -25,8 +25,8 @@
   <meta property="og:type" content="website" />
   <meta property="og:locale" content="ja_JP" />
   <meta property="og:site_name" content="ChuCkle Park Bar" />
-  <meta property="og:title" content="ChuCkle Park Bar｜本郷の路地で、ひそやかな社交と深いくつろぎを" />
-  <meta property="og:description" content="名古屋・本郷の路地にあるバー。社交も隠れ家も楽しめる空間で、豊富なドリンクと本格フードをご提供。深夜2時まで温かいお料理を提供。" />
+   <meta property="og:title" content="ChuCkle Park Bar｜夜を、もう一口たのしく。" />
+   <meta property="og:description" content="名古屋・本郷の路地にあるバー。夜を、もう一口たのしく。本格の一皿と幅広いドリンク、にぎやかで人当たりのいい接客。深夜2時まで温かいお料理を提供。" />
   <meta property="og:url" content="https://chuckle-park-bar.github.io/" />
   <meta property="og:image" content="https://chuckle-park-bar.github.io/images/chuckleparkbar-logo.png" />
   <meta property="og:image:width" content="1200" />
@@ -39,8 +39,8 @@
   <meta property="business:contact_data:postal_code" content="465-0059" />
   <meta property="business:contact_data:country_name" content="Japan" />
   <meta name="twitter:card" content="summary_large_image" />
-  <meta name="twitter:title" content="ChuCkle Park Bar（チャックル パーク バー）| 本郷の路地で、ひそやかな社交と深いくつろぎを" />
-  <meta name="twitter:description" content="名古屋・本郷の路地にあるバー。社交も隠れ家も楽しめる空間。豊富なドリンクと本格フード。カウンター8席・テーブル2〜8名、深夜2時まで。ご予約はお電話で。" />
+   <meta name="twitter:title" content="ChuCkle Park Bar（チャックル パーク バー）| 夜を、もう一口たのしく。" />
+   <meta name="twitter:description" content="名古屋・本郷の路地にあるバー。夜を、もう一口たのしく。本格の一皿と幅広いドリンク、にぎやかで人当たりのいい接客。カウンター8席・テーブル2〜8名、深夜2時まで。ご予約はお電話で。" />
   <meta name="twitter:image" content="https://chuckle-park-bar.github.io/images/chuckleparkbar-logo.png" />
   <meta name="twitter:image:alt" content="ChuCkle Park Bar ロゴ" />
   <meta name="twitter:creator" content="@chuckleparkbar" />
@@ -145,7 +145,7 @@
       "width": 512,
       "height": 512
     },
-    "description": "本郷駅徒歩4分、本郷の路地にある隠れ家バー。本郷エリアで深夜3時まで営業し、豊富なドリンクと本格フードをご提供。カウンター8席・テーブル2〜8名対応の本郷のバーです。",
+    "description": "本郷駅徒歩4分、本郷の路地にある隠れ家バー。本郷エリアで深夜3時まで営業し、夜を、もう一口たのしく。本格の一皿と幅広いドリンク、にぎやかで人当たりのいい接客。カウンター8席・テーブル2〜8名対応の本郷のバーです。",
     "servesCuisine": ["Bar", "Cocktails", "Whisky", "Japanese"],
     "priceRange": "¥¥",
     "telephone": "+81-52-990-9426",
@@ -308,8 +308,8 @@
           <img src="images/chuckleparkbar-logo.png" alt="ChuCkle Park Bar メインロゴ" class="w-48 h-48 sm:w-56 sm:h-56 md:w-64 md:h-64 object-contain invert select-none pointer-events-none" draggable="false" />
         </div>
         <!-- タイトル（ロゴ下に移動） -->
-        <h1 class="text-3xl sm:text-4xl font-semibold tracking-tight md:text-6xl leading-tight text-white drop-shadow-lg md:drop-shadow-none max-w-xs sm:max-w-lg md:max-w-none mx-auto" data-aos="fade-up" data-aos-delay="80">本郷の路地で<br/>ひそやかな社交と<br/>深いくつろぎを</h1>
-        <p class="mx-auto mt-3 sm:mt-5 max-w-sm sm:max-w-xl md:max-w-2xl text-zinc-100 md:text-zinc-300 text-sm sm:text-base drop-shadow-md md:drop-shadow-none" data-aos="fade-up" data-aos-delay="140">交わる声、ほどける本音…社交も隠れ家もここに。<br/>豊富なドリンクと本格フードで、あなたの時間を大切にします。</p>
+          <h1 class="text-3xl sm:text-4xl font-semibold tracking-tight md:text-6xl leading-tight text-white drop-shadow-lg md:drop-shadow-none max-w-xs sm:max-w-lg md:max-w-none mx-auto" data-aos="fade-up" data-aos-delay="80">夜を、もう一口たのしく。</h1>
+          <p class="mx-auto mt-3 sm:mt-5 max-w-sm sm:max-w-xl md:max-w-2xl text-zinc-100 md:text-zinc-300 text-sm sm:text-base drop-shadow-md md:drop-shadow-none" data-aos="fade-up" data-aos-delay="140">本格の一皿と幅広いドリンク。<br/>にぎやかで人当たりのいい接客。</p>
         <div class="mt-6 sm:mt-8 md:mt-10 flex flex-col items-center justify-center gap-3 sm:flex-row" data-aos="zoom-in" data-aos-delay="220">
           <a href="#reserve" class="rounded-2xl bg-brand px-6 py-3 font-medium text-black hover:bg-brand-dark shadow-lg">席を予約</a>
           <a href="#gallery" class="rounded-2xl border border-white/30 bg-white/10 backdrop-blur-sm px-6 py-3 font-medium hover:bg-white/20">ギャラリーを見る</a>
@@ -330,13 +330,14 @@
     <div class="max-w-6xl mx-auto px-4 grid md:grid-cols-2 gap-10 items-center">
       <div data-aos="fade-up" data-aos-duration="800">
         <h2 class="text-3xl font-semibold mb-4">コンセプト</h2>
-        <p class="text-zinc-300 leading-7">本郷の路地にあるバーで、社交も隠れ家も楽しめる空間をご提供しています。豊富なドリンクメニューと本格的なフードで、どなたでも心地よく過ごしていただけます。カウンター席では静かにお一人の時間を、テーブル席では仲間と賑やかにお楽しみください。</p>
-        <ul class="mt-6 space-y-2 text-zinc-400">
-          <li>・カウンター8席（お一人でも入りやすい雰囲気）</li>
-          <li>・テーブル席あり（2〜8名様まで対応可能）</li>
-          <li>・豊富なドリンクメニューと本格フード</li>
-          <li>・深夜2:00まで温かいお料理を提供</li>
-        </ul>
+          <p class="text-zinc-300 leading-7">本郷の路地にあるバーで、社交も隠れ家も楽しめる空間をご提供しています。本格の一皿と幅広いドリンクで、どなたでも心地よく過ごしていただけます。にぎやかで人当たりのいい接客で、カウンター席では静かにお一人の時間を、テーブル席では仲間と賑やかにお楽しみください。</p>
+          <ul class="mt-6 space-y-2 text-zinc-400">
+            <li>・カウンター8席（お一人でも入りやすい雰囲気）</li>
+            <li>・テーブル席あり（2〜8名様まで対応可能）</li>
+            <li>・本格の一皿と幅広いドリンク</li>
+            <li>・にぎやかで人当たりのいい接客</li>
+            <li>・深夜2:00まで温かいお料理を提供</li>
+          </ul>
       </div>
       <div data-aos="fade-up" data-aos-duration="800" class="flex justify-end">
         <img class="w-96 h-128 rounded-2xl border border-white/10 object-cover" src="images/exterior.jpg" alt="外観写真" />

--- a/manifest.webmanifest
+++ b/manifest.webmanifest
@@ -1,7 +1,7 @@
 {
   "name": "ChuCkle Park Bar",
   "short_name": "CP Bar",
-  "description": "本郷の路地にあるバー。社交も隠れ家も楽しめる空間で、豊富なドリンクと本格フード。",
+  "description": "本郷の路地にあるバー。夜を、もう一口たのしく。本格の一皿と幅広いドリンク、にぎやかで人当たりのいい接客。",
   "start_url": "/index.html",
   "scope": "/",
   "display": "standalone",


### PR DESCRIPTION
## Summary
- update main catch copy and sub tagline across site
- refresh meta tags and JSON-LD descriptions for new messaging
- adjust concept section and manifest description

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b2b60f658083218e63d45f0dd661ce