### PR TITLE
feat: set site title to store name

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,8 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
 
-  <title>ChuCkle Park Bar（チャックル パーク バー）｜本郷のオーセンティックじゃないBAR</title>
+  <title>ChuCkle Park Bar | 本郷のオーセンティックじゃないBAR</title>
+  <meta name="title" content="ChuCkle Park Bar | 本郷のオーセンティックじゃないBAR" />
   <meta name="description" content='名古屋・本郷のオーセンティックじゃないBAR『ChuCkle Park Bar』。BARだけどごはんがうまい、ふらっと入りやすい店。おひとり様でもグループでも、気さくなスタッフがお迎え。サクッとも、ゆる〜っとも。'>
 
   <meta name="author" content="ChuCkle Park Bar" />


### PR DESCRIPTION
## Summary
- adjust HTML title meta tags to reflect the bar name

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68c4cba86dd88321bf5668d1af428169